### PR TITLE
Capute toggl details in JIRA's work log item description

### DIFF
--- a/JiraTogglSync.CommandLine/ConfigurationHelper.cs
+++ b/JiraTogglSync.CommandLine/ConfigurationHelper.cs
@@ -10,16 +10,31 @@ namespace JiraTogglSync.CommandLine
     {
         static byte[] entropy = Encoding.Unicode.GetBytes("JiraTogglSync.Salt");
 
-        public static string GetValueFromConfig(string key, Func<string> askForValue)
+        public static string GetValueFromConfig(string key, Func<string> askForValue, Func<string> defaultValue = null, Func<string,bool> isValueValid = null)
         {
             var value = ConfigurationManager.AppSettings[key];
 
             if (value != null)
                 return value;
 
-            value = askForValue();
+            value = AskForValueOrUseDefault(askForValue, defaultValue);
+
+            while (isValueValid != null && !isValueValid(value))
+            {
+                value = AskForValueOrUseDefault(askForValue, defaultValue);
+            }
 
             SaveConfig(key, value);
+
+            return value;
+        }
+
+        private static string AskForValueOrUseDefault(Func<string> askForValue, Func<string> defaultValue)
+        {
+            var value = askForValue();
+
+            if (string.IsNullOrEmpty(value) && defaultValue != null)
+                value = defaultValue();
 
             return value;
         }

--- a/JiraTogglSync.CommandLine/Program.cs
+++ b/JiraTogglSync.CommandLine/Program.cs
@@ -10,7 +10,19 @@ namespace JiraTogglSync.CommandLine
 		static void Main(string[] args)
 		{
 			var togglApiKey = ConfigurationHelper.GetEncryptedValueFromConfig("toggl-api-key", () => AskFor("Toggl API Key"));
-			var toggl = new TogglService(togglApiKey);
+			var jiraWorkItemDescriptionTemplate = ConfigurationHelper.GetValueFromConfig("jira-decription-template", 
+                                                                                        () => AskFor("JIRA Description template"), 
+                                                                                        defaultValue: () => "{{toggl:id}}\r\n{{toggl:description}}",
+                                                                                        isValueValid: v =>
+                                                                                        {
+                                                                                            if (v.Contains("{{toggl:id}}"))
+                                                                                                return true;
+
+                                                                                            Console.WriteLine("Error: Template must contain placeholder for toggl time entry id: {{toggl:id}}");
+                                                                                            return false;
+                                                                                        });
+
+            var toggl = new TogglService(togglApiKey, jiraWorkItemDescriptionTemplate);
 			Console.WriteLine("Toggl: Connected as {0}", toggl.GetUserInformation());
 
 			var jiraInstance = ConfigurationHelper.GetValueFromConfig("jira-instance", () => AskFor("JIRA Instance"));

--- a/JiraTogglSync.Services/JiraRestService..cs
+++ b/JiraTogglSync.Services/JiraRestService..cs
@@ -28,7 +28,7 @@ namespace JiraTogglSync.Services
 		{
 			var timeSpentSeconds = (int)entry.RoundedDuration.TotalSeconds;
 
-			_jira.CreateWorklog(new IssueRef {id = entry.IssueKey}, timeSpentSeconds, "", entry.Start);
+			_jira.CreateWorklog(new IssueRef {id = entry.IssueKey}, timeSpentSeconds, entry.Description, entry.Start);
 		}
 
 		private static Issue ConvertToIncident(Issue<IssueFields> issue)

--- a/JiraTogglSync.Tests/TogglServiceTests.cs
+++ b/JiraTogglSync.Tests/TogglServiceTests.cs
@@ -10,7 +10,7 @@ namespace JiraTogglSync.Tests
         [TestMethod]
         public void CanBeCreated()
         {
-            new TogglService("my-api-key");
+            new TogglService("my-api-key", decriptionTemplate: "");
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,23 @@ A list of issues will then be shown. You can accept to enter a worklog for it by
 
 Only issues from the last 14 days with a matching JIRA key will be selected.
 
+Parameters
+============
+### jira-decription-template
+When Toggl's time entry is converted to JIRA's work log entry, additional information from toggl time entry can be stored in JIRA's work log comment.
+
+Following placeholders that can be used in template:
+- **{{toggl:id}}** - Required to be present somewhere in the template
+- **{{toggl:description}}**
+- **{{toggl:createdWith}}**
+- **{{toggl:isBillable}}**
+- **{{toggl:projectId}}**
+- **{{toggl:tagNames}}**
+- **{{toggl:taskId}}**
+- **{{toggl:updatedOn}}**
+
+Default placeholder: `{{toggl:id}}\r\n{{toggl:description}}`
+
 Contributors
 ============
 


### PR DESCRIPTION
This is in reference to #6 

My thoughts about this pull requests:
* I don't think that `TogglService.cs` is a good place to use `descriptionTemplate`, ideally it should be used somewhere in `WorksheetSyncService.cs`, but it is not yet possible because `IWorksheetSourceService` returns `IEnumerable<WorkLogEntry>` (so we are losing reference original toggl's 'TimeEntry').
* It appears that `WorksheetSyncService.cs` was designed with intention to be as generic as possible, but it dependencies have strong coupling to JIRA implementation. - I suggest we either make it truly generic, or explicitly modify it to be TogglToJiraSyncService

Before we can proceed with implementing purge feature, we need two things:

1. Decide how to refactor code based on observations above. Hopefully we could add more tests in that process as well
2. Agree on how purge feature should work. I will be first capturing details here: https://github.com/christianrondeau/jira-toggl-sync/wiki/Feature:-Purge

Thanks :)
